### PR TITLE
Refactor notification text rendering

### DIFF
--- a/app/views/xmpp/_issue.text.erb
+++ b/app/views/xmpp/_issue.text.erb
@@ -1,0 +1,13 @@
+<%= "#{issue.tracker.name} ##{issue.id}: #{issue.subject}" %>
+
+<%= "#{l(:field_author)}: #{issue.author.name}" %>
+<%= "#{l(:field_url)}: #{redmine_url}/issues/#{issue.id}" %>
+<%= "#{l(:field_project)}: #{issue.project}" %>
+<%= "#{l(:field_tracker)}: #{issue.tracker.name}" %>
+<%= "#{l(:field_priority)}: #{issue.priority.name}" %>
+<%= "#{l(:field_assigned_to)}: #{issue.assigned_to.name}\n" if issue.assigned_to -%>
+<%= "#{l(:field_start_date)}: #{issue.start_date.strftime("%d.%m.%Y")}\n" if issue.start_date -%>
+<%= "#{l(:field_due_date)}: #{issue.due_date.strftime("%d.%m.%Y")}\n" if issue.due_date -%>
+<%= "#{l(:field_estimated_hours)}: #{issue.estimated_hours} #{l(:field_hours)}\n" if issue.estimated_hours -%>
+<%= "#{l(:field_done_ratio)}: #{issue.done_ratio}%\n" if issue.done_ratio -%>
+<%= "#{l(:field_status)}: #{issue.status.name}\n" if issue.status -%>

--- a/app/views/xmpp/issue_add.text.erb
+++ b/app/views/xmpp/issue_add.text.erb
@@ -1,0 +1,7 @@
+<%= l(:text_issue_added, id: "##{issue.id}", author: issue.author) %>
+
+<%= "#{issue.description}" if issue.description.present? %>
+
+----------------------------------------
+
+<%= render partial: "xmpp/issue", formats: [:text] %>

--- a/app/views/xmpp/issue_edit.text.erb
+++ b/app/views/xmpp/issue_edit.text.erb
@@ -1,0 +1,12 @@
+<%= "(#{l(:field_private_notes)}) " if journal.private_notes? -%>
+<%= l(:text_issue_updated, id: "##{issue.id}", author: journal.user) %>
+
+<% details_to_strings(journal_details, true).each do |string| -%>
+    - <%= string %>
+<% end -%>
+
+<%= "#{journal.notes}" if journal.notes? %>
+
+----------------------------------------
+
+<%= render partial: "xmpp/issue", formats: [:text] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,3 @@ en:
   xmpp_label_password: Password
   xmpp_label_notification_settings: Notification settings
   xmpp_label_send_to_watchers: Send notifications to watchers?
-  xmpp_issue_created: "Issue was created:"
-  xmpp_issue_updated: "Issue was updated:"
-  xmpp_update_author: Author of changes

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -4,6 +4,3 @@ ru:
   xmpp_label_password: Пароль
   xmpp_label_notification_settings: Настройки оповещений
   xmpp_label_send_to_watchers: Оповещать наблюдателей?
-  xmpp_issue_created: Создана задача
-  xmpp_issue_updated: Обновлена задача
-  xmpp_update_author: Автор изменений

--- a/lib/notifier_hook.rb
+++ b/lib/notifier_hook.rb
@@ -1,98 +1,49 @@
 require_relative './xmpp_bot'
 
 class NotifierHook < Redmine::Hook::Listener
-
-  def initialize
-  end
-
   #TODO: it is plans to rename hooks in upstream
   def controller_issues_new_after_save(context={})
-    redmine_url = "#{Setting[:protocol]}://#{Setting[:host_name]}"
     issue = context[:issue]
 
-    text = l(:xmpp_issue_created) + " ##{issue.id}\n\n"
-    text += l(:field_author) + ": #{issue.author.name}\n"
-    text += l(:field_subject) + ": #{issue.subject}\n"
-    text += l(:field_url) + ": #{redmine_url}/issues/#{issue.id}\n"
-    text += l(:field_project) + ": #{issue.project}\n"
-    text += l(:field_tracker) + ": #{issue.tracker.name}\n"
-    text += l(:field_priority) + ": #{issue.priority.name}\n"
-    if issue.assigned_to
-      text += l(:field_assigned_to) + ": #{issue.assigned_to.name}\n"
+    deliver(issue) do |user|
+      XmppNotificationRenderer.new(context, user).render_issue
     end
-    if issue.start_date
-      text += l(:field_start_date) + ": #{issue.start_date.strftime("%d.%m.%Y")}\n"
-    end
-    if issue.due_date
-      text += l(:field_due_date) + ": #{issue.due_date.strftime("%d.%m.%Y")}\n"
-    end
-    if issue.estimated_hours
-      text += l(:field_estimated_hours) + ": #{issue.estimated_hours} " + l(:field_hours) + "\n"
-    end
-    if issue.done_ratio
-      text += l(:field_done_ratio) + ": #{issue.done_ratio}%\n"
-    end
-    if issue.status
-      text += l(:field_status) + ": #{issue.status.name}\n"
-    end
-    text += "\n\n#{issue.description}"
-
-    deliver text, issue
   end
 
   def controller_issues_edit_after_save(context={})
-    redmine_url = "#{Setting[:protocol]}://#{Setting[:host_name]}"
-    issue = context[:issue]
     journal = context[:journal]
 
-    text = l(:xmpp_issue_updated) + " ##{issue.id}\n\n"
-    text += l(:xmpp_update_author) + ": #{journal.user.name}\n"
-    text += l(:field_subject) + ": #{issue.subject}\n"
-    text += l(:field_url) + ": #{redmine_url}/issues/#{issue.id}\n"
-    text += l(:field_project) + ": #{issue.project}\n"
-    text += l(:field_tracker) + ": #{issue.tracker.name}\n"
-    text += l(:field_priority) + ": #{issue.priority.name}\n"
-    if issue.assigned_to
-      text += l(:field_assigned_to) + ": #{issue.assigned_to.name}\n"
+    deliver(journal) do |user|
+      XmppNotificationRenderer.new(context, user).render_journal
     end
-    if issue.start_date
-      text += l(:field_start_date) + ": #{issue.start_date.strftime("%d.%m.%Y")}\n"
-    end
-    if issue.due_date
-      text += l(:field_due_date) + ": #{issue.due_date.strftime("%d.%m.%Y")}\n"
-    end
-    if issue.estimated_hours
-      text += l(:field_estimated_hours) + ": #{issue.estimated_hours} " + l(:field_hours) + "\n"
-    end
-    if issue.done_ratio
-      text += l(:field_done_ratio) + ": #{issue.done_ratio}%\n"
-    end
-    if issue.status
-      text += l(:field_status) + ": #{issue.status.name}\n"
-    end
-    text += "\n\n#{journal.notes}"
-
-    deliver text, journal
   end
-
 
   private
 
-  def deliver(message, object)
-    author = object.try(:user) || object.try(:author)
+  # @yield [user] The block generates message text for each recepient
+  # @yieldparam [User] user
+  # @yieldreturn [String] message text
+  def deliver(object)
+    notification_recipients = notification_recipients(object)
+    return if notification_recipients.empty?
+
+    Rails.logger.info "Sending XMPP notification to: #{notification_recipients.map(&:xmpp_jid).join(', ')}"
+    notification_recipients.each do |user|
+      message = yield(user)
+      Bot.deliver user.xmpp_jid, message
+    end
+  end
+
+  def notification_recipients(object)
     notification_recipients = object.notified_users
     notification_recipients += object.notified_watchers if config["send_to_watchers"]
     notification_recipients.uniq!
-    notification_recipients.delete(author) if author.logged? && author.pref.no_self_notified
-    return if notification_recipients.empty?
-    jids = notification_recipients.collect {|jid| jid.xmpp_jid.presence}.flatten.compact
-    return if jids.empty?
-
-    Rails.logger.info "Sending XMPP notification to: #{jids.join(', ')}"
-    jids.each do |jid|
-      next unless jid.present?
-      Bot.deliver jid, message
+    notification_recipients.keep_if {|user| user.xmpp_jid.present? }
+    if notification_recipients.any?
+      author = object.try(:user) || object.try(:author)
+      notification_recipients.delete(author) if author.logged? && author.pref.no_self_notified
     end
+    notification_recipients
   end
 
   def config

--- a/lib/xmpp_notification_renderer.rb
+++ b/lib/xmpp_notification_renderer.rb
@@ -1,0 +1,53 @@
+class XmppNotificationRenderer
+  def initialize(context, user)
+    @view = XmppNotificationView.new(context, user)
+  end
+
+  def render_issue
+    view.render(file: "xmpp/issue_add.text.erb")
+  end
+
+  def render_journal
+    view.render(file: "xmpp/issue_edit.text.erb")
+  end
+
+  private
+
+  attr_reader :view
+
+  class XmppNotificationView < ActionView::Base
+    include Redmine::I18n
+    include IssuesHelper
+
+    attr_reader :issue, :journal, :user
+
+    def initialize(context, user)
+      @issue = context[:issue]
+      @journal = context[:journal]
+      @user = user
+      super(ActionController::Base.view_paths)
+    end
+
+    def redmine_url
+      "#{Setting[:protocol]}://#{Setting[:host_name]}"
+    end
+
+    def journal_details
+      journal.visible_details(user) if journal
+    end
+
+    def render(*)
+      I18n.with_locale(locale) do
+        eliminate_multiple_blank_lines(super)
+      end
+    end
+
+    def eliminate_multiple_blank_lines(text)
+      text.gsub(/^$\n+/, "\n").strip
+    end
+
+    def locale
+      user.language.presence || I18n.default_locale
+    end
+  end
+end


### PR DESCRIPTION
Use ERB templates for XMPP notifications just like it works for email.
Now XMPP notification text includes more details and looks more similar to the email notification content (e.g. it includes how some field was changed, old and new values).

As an example of change format look at the test: https://github.com/redmine-xmpp/notifications/blob/6790b909a2fa163a922881a5ebde52c2353b74d5/test/integration/notifier_hook_test.rb#L13-L32