### PR TITLE
hint not save to server archive

### DIFF
--- a/lib/xmpp_bot.rb
+++ b/lib/xmpp_bot.rb
@@ -228,6 +228,9 @@ class Bot
   def deliver jid, message_text, message_type = :chat
     message = Message.new(jid, message_text)
     message.type = message_type
+    hint = REXML::Element::new("no-permanent-store")
+    hint.add_namespace("urn:xmpp:hints")
+    message.add_element(hint)
     client.tap {|client|
       client.send(message) unless client.nil?
     }


### PR DESCRIPTION
Saving notifications in xmpp server archive unnecessary
The <no-permanent-store/> hint informs entities that they shouldn't store the message in any permanent or semi-permanent public or private archive (such as described in Message Archiving XEP-0136 and Message Archive Management XEP-0313 ) or in logs (such as chatroom logs).