### PR TITLE
Pass author to wiki update job

### DIFF
--- a/app/workers/wiki_updated_notifier.rb
+++ b/app/workers/wiki_updated_notifier.rb
@@ -2,7 +2,7 @@ class WikiUpdatedNotifier
   include Sidekiq::Worker
   include XmppNotificationSender
 
-  def perform(page_id)
-    updated_wiki(page: WikiPage.find(page_id))
+  def perform(page_id, author_id)
+    updated_wiki(page: WikiPage.find(page_id), author: User.find_by_id(author_id))
   end
 end

--- a/lib/xmpp_notification_sender.rb
+++ b/lib/xmpp_notification_sender.rb
@@ -20,6 +20,7 @@ module XmppNotificationSender
   end
 
   def updated_wiki(context)
+    context[:page].content.author = context[:author] unless context[:author].nil?
     page = context[:page]
 
     deliver(page.content) do |user|
@@ -52,7 +53,7 @@ module XmppNotificationSender
       when :updated_issue
         IssueUpdatedNotifier.perform_async(context[:issue].id, context[:journal].id)
       when :updated_wiki
-        WikiUpdatedNotifier.perform_async(context[:page].id)
+        WikiUpdatedNotifier.perform_async(context[:page].id, context[:page].content.author_id)
       when :message
         MessageNotifier.perform_async(context[:message].id)
       else


### PR DESCRIPTION
Redmine may change author in the page.content to something different
in some cases. This change is not persisted and if we don't pass it
to the sidekiq worker additionally it will be lost and the page update
will be rendered with the author value from the database. Since it
differs from the intended value in the cases when Redmine replaces it
this may result in wrong values in rendering. One of such cases is
when the user changes the parent page of a wiki page to something
different without changing page content. In this case page.content.author
points to the author of the last content change but Redmine changes it
to the user who performed the parent page change without creating
new content intance and without persisting the author change to
the last content object.